### PR TITLE
Suppressed the -var-create error message at a certain condition

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1278,10 +1278,10 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 }
             } else {
                 this.sendErrorResponse(
-                        response,
-                        1,
-                        err instanceof Error ? err.message : String(err)
-                    );
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
             }
         }
     }

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1274,7 +1274,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         } catch (err) {
             if (err instanceof Error) {
                 if (err.message === '-var-create: unable to create variable object') {
-                    return;
+                    this.sendResponse(response);
                 }
             } else {
                 this.sendErrorResponse(

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1272,11 +1272,17 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(
-                response,
-                1,
-                err instanceof Error ? err.message : String(err)
-            );
+            if (err instanceof Error) {
+                if (err.message === '-var-create: unable to create variable object') {
+                    return;
+                }
+            } else {
+                this.sendErrorResponse(
+                        response,
+                        1,
+                        err instanceof Error ? err.message : String(err)
+                    );
+            }
         }
     }
 


### PR DESCRIPTION
When a user hovers over a comment or a non-variable statement (loops for examples). The error message "-var-create: unable to create variable object" popped up. I disabled this behaviour