### PR TITLE
Add global variables scope

### DIFF
--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -2106,6 +2106,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
             name: elementToAdd.expression,
             value: elementToAdd.value ?? '',
             memoryReference: `&(${elementToAdd.expression})`,
+            type: elementToAdd.type,
             variablesReference:
                 parseInt(elementToAdd.numchild, 10) > 0
                     ? this.variableHandles.create({

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -1195,13 +1195,13 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                     this.variableHandles.create(frameVarRef),
                     false
                 ),
+                new Scope('Global', this.variableHandles.create(globals), true),
+                new Scope('Static', this.variableHandles.create(statics), true),
                 new Scope(
                     'Registers',
                     this.variableHandles.create(registers),
                     true
-                ),
-                new Scope('Global', this.variableHandles.create(globals), true),
-                new Scope('Static', this.variableHandles.create(statics), true),
+                )
             ],
         };
 

--- a/src/gdb/GDBDebugSessionBase.ts
+++ b/src/gdb/GDBDebugSessionBase.ts
@@ -105,9 +105,9 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
      * typically supplied with the --config-frozen command line argument.
      */
     protected static frozenRequestArguments?: { request?: string };
-    
+
     // A variable to store current source file the debugger stopped in. For global variables
-    protected currentFile: string = '';
+    protected currentSourcetFile: string = '';
 
     protected gdb!: IGDBBackend;
     protected isAttach = false;
@@ -1933,7 +1933,7 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
                 break;
             case 'stopped': {
                 let suppressHandleGDBStopped = false;
-                this.currentFile = resultData.frame.fullname;
+                this.currentSourcetFile = resultData.frame.fullname;
                 if (this.gdb.isNonStopMode()) {
                     const id = parseInt(resultData['thread-id'], 10);
                     for (const thread of this.threads) {
@@ -2098,30 +2098,205 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
     protected async handleVariableRequestGlobal(): Promise<
         DebugProtocol.Variable[]
     > {
+        // Create empty array response for global variaables
         const globalVariables: DebugProtocol.Variable[] = [];
+        // Check if any global variables are stored in the adapter's variable map. They have threadId of -1, frameId of -1, and depth of -1 as well
+        const existingGlobalVars = this.gdb.varManager.getVars(
+            { threadId: -1, frameId: -1 },
+            -1
+        );
+        // Get all global variables from GDB
         const globalvars = await mi.sendSymbolInfoVars(this.gdb);
-        //const globalvars: mi.MISymbolInfoVarsResponse = await mi.getGlobalVars(this.gdb);
-        if (globalvars) {
-            for (const symbolgroup of globalvars.symbols.debug) {
-                // if (symbolgroup.symbols.description.includes('static')) {
-                // }
-                for (const symbol of symbolgroup.symbols) {
-                    const varValue = await mi.sendDataEvaluateExpression(
-                        this.gdb,
-                        symbol.name
+        // if there are no global variables stored in adapter's map
+        if (!existingGlobalVars) {
+            if (globalvars.symbols.debug.length > 0) {
+                // Iterate over global variables debug groups (global variables are grouped by source file)
+                for (const symbolgroup of globalvars.symbols.debug) {
+                    const symbolGroupFile = symbolgroup.filename;
+                    // Iterate over each global variable in the group
+                    for (const symbol of symbolgroup.symbols) {
+                        // Create a GDB/MI variable object for each global variable
+                        const miVarObj = await mi.sendVarCreate(this.gdb, {
+                            name: symbol.name,
+                            expression: symbol.name,
+                            frame: 'floating',
+                        });
+                        // Add the variable to the variable map
+                        this.gdb.varManager.addVar(
+                            { threadId: -1, frameId: -1 }, //threadID = -1, frameID = -1 for global variables. This is an implementation choice and not a value used by GDB
+                            -1, //
+                            symbol.name, // variable/expression name
+                            true, // is it a variable?
+                            false, // is it a child variable? we don't store child variables in this method. It is only stored in VariableRequestObject
+                            miVarObj, // return of GDB/MI variable object creation function
+                            symbol.type // type of the variable
+                        );
+                        // If we have an array parent entry, we need to display the address.
+                        if (arrayRegex.test(miVarObj.type)) {
+                            const addr = await mi.sendDataEvaluateExpression(
+                                this.gdb,
+                                `&(${miVarObj.name})`
+                            );
+                            miVarObj.value = addr.value ? addr.value : '';
+                        }
+                        // If variable is not static, just add it to response
+                        if (symbol.description.includes('static')) {
+                            // Check if current source file is the same as symbol's filename
+                            if (symbolGroupFile === this.currentSourcetFile) {
+                                // If it is the same, add static variable to response list
+                                globalVariables.push({
+                                    name: miVarObj.name,
+                                    value: miVarObj.value ?? '',
+                                    memoryReference: `&(${miVarObj.name})`,
+                                    variablesReference:
+                                        parseInt(miVarObj.numchild, 10) > 0
+                                            ? this.variableHandles.create({
+                                                  type: 'object',
+                                                  varobjName: miVarObj.name,
+                                                  frameHandle: -1, // Global variables don't have a frame
+                                              })
+                                            : 0,
+                                });
+                            }
+                        } else {
+                            // If not static variable, just add it to response
+                            globalVariables.push({
+                                name: miVarObj.name,
+                                value: miVarObj.value ?? '',
+                                memoryReference: `&(${miVarObj.name})`,
+                                variablesReference:
+                                    parseInt(miVarObj.numchild, 10) > 0
+                                        ? this.variableHandles.create({
+                                              type: 'object',
+                                              varobjName: miVarObj.name,
+                                              frameHandle: -1, // Global variables don't have a frame
+                                          })
+                                        : 0,
+                            });
+                        }
+                    }
+                }
+            } else {
+                // No global variables found in GDB either
+            }
+        } else {
+            // There are global variables in the adapter's variable map
+            if (globalvars.symbols.debug.length > 0) {
+                // There are global variables in GDB as well
+                // Make sure the adapter's map and GDB are in sync
+                // Array of variables to erase from adapter's map
+                for (const variableInMap of existingGlobalVars) {
+                    // Ignore it if it's a child variable or an expression
+                    if (variableInMap.isVar && !variableInMap.isChild) {
+                        // request update from GDB
+                        const variableUpdate = await mi.sendVarUpdate(
+                            this.gdb,
+                            {
+                                name: variableInMap.varname,
+                            }
+                        );
+                        // If changelist has the length 0, the value of update will be undefined
+                        // If update is undefined, that means the variable object still exists in GDB/MI, but it hasn't changed it's value.
+                        // When a variable object is erased from GDB/MI, the -var-update command will trigger an error
+                        const update = variableUpdate.changelist[0];
+                        let pushFlag = true;
+                        if (update) {
+                            // If in_scope === true, that means the value is valid and it should be updated in the variable map
+                            if (update.in_scope === 'true') {
+                                if (update.name === variableInMap.varname) {
+                                    // Update the value
+                                    variableInMap.value = update.value;
+                                    variableInMap.type =
+                                        update.type_changed === 'true'
+                                            ? update.new_type
+                                            : variableInMap.type;
+                                    variableInMap.numchild =
+                                        update.type_changed === 'true'
+                                            ? update.new_num_children
+                                            : variableInMap.numchild;
+                                }
+                            } else if (update.in_scope === 'invalid') {
+                                // If in_scope === 'invalid', that means variable no longer exists, i.e. a new executable file is being debugged
+                                this.gdb.varManager.removeVar(
+                                    { threadId: -1, frameId: -1 },
+                                    -1,
+                                    variableInMap.varname
+                                );
+                                pushFlag = false;
+                            }
+                            // in_scope === 'false' is not possible for global variables
+                        }
+                        if (pushFlag) {
+                            // Check if the variable is static, then make sure we are in the right source file before sending it as a response
+                            const variableSymbol = await mi.sendSymbolInfoVars(
+                                this.gdb,
+                                {
+                                    name: variableInMap.varname,
+                                }
+                            );
+                            if (
+                                variableSymbol.symbols.debug[0].symbols[0].description.includes(
+                                    'static'
+                                )
+                            ) {
+                                if (
+                                    variableSymbol.symbols.debug[0].filename ===
+                                    this.currentSourcetFile
+                                ) {
+                                    // If we are in the right source file, show the corresponding static variables
+                                    globalVariables.push({
+                                        name: variableInMap.varname,
+                                        value: variableInMap.value ?? '',
+                                        memoryReference: `&(${variableInMap.varname})`,
+                                        variablesReference:
+                                            parseInt(
+                                                variableInMap.numchild,
+                                                10
+                                            ) > 0
+                                                ? this.variableHandles.create({
+                                                      type: 'object',
+                                                      varobjName:
+                                                          variableInMap.varname,
+                                                      frameHandle: -1, // Global variables don't have a frame
+                                                  })
+                                                : 0,
+                                    });
+                                }
+                            } else {
+                                // If not static variable, then just print it
+                                globalVariables.push({
+                                    name: variableInMap.varname,
+                                    value: variableInMap.value ?? '',
+                                    memoryReference: `&(${variableInMap.varname})`,
+                                    variablesReference:
+                                        parseInt(variableInMap.numchild, 10) > 0
+                                            ? this.variableHandles.create({
+                                                  type: 'object',
+                                                  varobjName:
+                                                      variableInMap.varname,
+                                                  frameHandle: -1, // Global variables don't have a frame
+                                              })
+                                            : 0,
+                                });
+                            }
+                        }
+                    }
+                }
+            } else {
+                // There are no global variables in GDB
+                // Erase global variables from adapter's map
+                for (const variableInMap of existingGlobalVars) {
+                    this.gdb.varManager.removeVar(
+                        { threadId: -1, frameId: -1 },
+                        -1,
+                        variableInMap.varname
                     );
-                    globalVariables.push({
-                        name: symbol.name,
-                        value: varValue.value ?? '',
-                        variablesReference: 0,
-                    });
                 }
             }
         }
-        console.log(globalVariables);
-        console.log(globalvars);
         return globalVariables;
     }
+
     protected async handleVariableRequestFrame(
         ref: FrameVariableReference
     ): Promise<DebugProtocol.Variable[]> {
@@ -2271,7 +2446,8 @@ export abstract class GDBDebugSessionBase extends LoggingDebugSession {
         // initialize variables array and dereference the frame handle
         const variables: DebugProtocol.Variable[] = [];
         const frameRef = this.frameHandles.get(ref.frameHandle);
-        if (!frameRef) {
+        if (!frameRef && ref.frameHandle !== -1) {
+            // Global variables have frameHandle -1
             return Promise.resolve(variables);
         }
 

--- a/src/integration-tests/test-programs/vars.c
+++ b/src/integration-tests/test-programs/vars.c
@@ -18,6 +18,7 @@ struct foo
     struct bar z;
     struct baz aa;
 };
+int global_a = 10;
 
 int main()
 {

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -60,7 +60,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
     });
 
     afterEach(async function () {
@@ -113,7 +113,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(
@@ -198,7 +198,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         // assert we can see the struct and its elements
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
@@ -267,7 +267,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(
@@ -291,7 +291,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         // assert we can see the 'foo' struct and its child 'bar' struct
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
@@ -392,7 +392,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(
@@ -417,7 +417,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         // assert we can see the array and its elements
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
@@ -498,7 +498,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(
@@ -528,7 +528,7 @@ describe('Variables Test Suite', function () {
         expect(
             scope.scopes.body.scopes.length,
             'Unexpected number of scopes returned'
-        ).to.equal(2);
+        ).to.equal(4);
         // assert we can see the array and its elements
         const vr = scope.scopes.body.scopes[0].variablesReference;
         const vars = await dc.variablesRequest({ variablesReference: vr });

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -122,6 +122,17 @@ describe('Variables Test Suite', function () {
         ).to.equal(numVars);
         verifyVariable(vars.body.variables[2], 'c', 'int', '35');
     });
+    
+    it('can read global variables in a program', async function (){
+        // read the variables
+        const vr = scope.scopes.body.scopes[1].variablesReference;
+        const vars = await dc.variablesRequest({ variablesReference: vr });
+        expect(
+            vars.body.variables.length,
+            'There is a different number of variables than expected'
+        ).to.be.greaterThanOrEqual(280); // a lot of global variables are in the example
+        verifyVariable(vars.body.variables[282], 'global_a', 'int', '10');
+    });
 
     it('can read and set simple registers in a program', async function () {
         // read the registers

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -52,6 +52,8 @@ export interface MIVarUpdateResponse {
         in_scope: string;
         type_changed: string;
         has_more: string;
+        new_type: string;
+        new_num_children: string;
     }>;
 }
 
@@ -228,8 +230,28 @@ export function sendVarSetFormatToHex(
 }
 
 export function sendSymbolInfoVars(
-    gdb: IGDBBackend
+    gdb: IGDBBackend,
+    params?: {
+        name?: string;
+        type?: string;
+        max_result?: string;
+        non_debug?: boolean;
+    }
 ): Promise<MISymbolInfoVarsResponse> {
-    const command = '-symbol-info-variables';
+    let command = '-symbol-info-variables';
+    if (params) {
+        if (params.name) {
+            command += ` --name ^${params.name}$`;
+        }
+        if (params.type) {
+            command += ` --type ^${params.type}$`;
+        }
+        if (params.max_result) {
+            command += ` --max-result ${params.max_result}`;
+        }
+        if (params.non_debug) {
+            command += ' --include-nondebug';
+        }
+    }
     return gdb.sendCommand(command);
 }

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -67,6 +67,28 @@ export interface MIVarPathInfoResponse {
     path_expr: string;
 }
 
+export interface MIDebugSymbol {
+    line: string;
+    name: string;
+    type: string;
+    description: string;
+}
+
+export interface MINonDebugSymbol {
+    address: string;
+    name: string;
+}
+export interface MISymbolInfoVarsDebug {
+    filename: string;
+    fullname: string;
+    symbols: MIDebugSymbol[];
+}
+export interface MISymbolInfoVarsResponse {
+    symbols: {
+        debug: MISymbolInfoVarsDebug[];
+        nondebug: MINonDebugSymbol[];
+    };
+}
 function quote(expression: string) {
     return `"${expression}"`;
 }
@@ -202,5 +224,12 @@ export function sendVarSetFormatToHex(
     name: string
 ): Promise<void> {
     const command = `-var-set-format ${name} hexadecimal`;
+    return gdb.sendCommand(command);
+}
+
+export function sendSymbolInfoVars(
+    gdb: IGDBBackend
+): Promise<MISymbolInfoVarsResponse> {
+    const command = '-symbol-info-variables';
     return gdb.sendCommand(command);
 }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -58,10 +58,17 @@ export interface RegisterVariableReference {
     regname?: string;
 }
 
+export interface GlobalVariableReference {
+    type: 'globals';
+    frameHandle: number;
+    regname?: string;
+}
+
 export type VariableReference =
     | FrameVariableReference
     | ObjectVariableReference
-    | RegisterVariableReference;
+    | RegisterVariableReference
+    | GlobalVariableReference;
 
 export interface MemoryRequestArguments {
     address: string;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -64,11 +64,18 @@ export interface GlobalVariableReference {
     regname?: string;
 }
 
+export interface StaticVariableReference {
+    type: 'statics';
+    frameHandle: number;
+    regname?: string;
+}
+
 export type VariableReference =
     | FrameVariableReference
     | ObjectVariableReference
     | RegisterVariableReference
-    | GlobalVariableReference;
+    | GlobalVariableReference
+    | StaticVariableReference;
 
 export interface MemoryRequestArguments {
     address: string;

--- a/src/varManager.ts
+++ b/src/varManager.ts
@@ -155,7 +155,7 @@ export class VarManager {
                 const createResponse = await sendVarCreate(this.gdb, {
                     frame: 'current',
                     expression: varobj.expression,
-                    frameRef,
+                    frameRef: frameRef?.frameId === -1 ? undefined : frameRef,
                 });
                 returnVar = this.addVar(
                     frameRef,


### PR DESCRIPTION
Adding global variables scope to variables window.

Steps for PR:
1. I added a new scope to the scopeRequest
2. Added a couple of interfaces and functions in the mi layer of the adapter to request symbol information (global variables) from gdb
3. Created a function that handles global variables request by doing the following:

- It queries for the symbol info from GDB. This table is grouped by source files
- Goes through source files one by one and start creating GDB/MI variable objects for each global variable inside
- Adds these variable objects to a variable map that already exists in the debug adapter
- Whenever a new request of global variables is requested, the adapter checks the local variables map before asking GDB to evaluate the variable object